### PR TITLE
Remove key prop, vanish the Key is not a prop warning

### DIFF
--- a/src/register.tsx
+++ b/src/register.tsx
@@ -12,8 +12,8 @@ addons.register("naver/storyboook-addon-preview", () => {
         title: "Code Preview",
         type: types.PANEL,
         paramKey: "preview",
-        render: ({ active, key }) => (
-            <AddonPanel active={active} key={key} >
+        render: ({ active }) => (
+            <AddonPanel active={active} >
                 <PreviewPanel />
             </AddonPanel>
         ),


### PR DESCRIPTION
Fixes the warning in conolse: `Key is not a prop. Trying to access it will result in undefined`